### PR TITLE
Add link to Debian binary packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ To use the system library
 
 RPM packages of this extension are available in [» Remi's RPM repository](https://rpms.remirepo.net/) and are named **php-lz4**.
 
+### Debian
+
+DEB packages of this extension are available in [» Ondřej Surý's DEB repository](https://deb.sury.org/) and are named **php-lz4**.
+
 
 ## Configuration
 


### PR DESCRIPTION
Debian Developer Ondřej Surý does provide binary DEB packages for this extension at https://deb.sury.org, it would be nice if this link could be added